### PR TITLE
Slowed down the speed on replays

### DIFF
--- a/assets/scripts/game/events.js
+++ b/assets/scripts/game/events.js
@@ -22,21 +22,21 @@ const paddle_width = 20
   let canvas = document.getElementById('gameCanvas')
   let canvasContext = canvas.getContext('2d')
 
-  canvasContext.font = '50px Impact'
-  canvasContext.fillStyle = '#0099CC'
-  canvasContext.textAlign = 'center'
-  canvasContext.fillText('HTML5 Arcade-style Tennis Game', canvas.width/2, canvas.height/2)
+    canvasContext.font = '50px Impact'
+    canvasContext.fillStyle = '#0099CC'
+    canvasContext.textAlign = 'center'
+    canvasContext.fillText('HTML5 Arcade-style Tennis Game', canvas.width/2, canvas.height/2)
 
-  canvasContext.font = '30px Arial'
-  canvasContext.fillStyle = '#0099CC'
-  canvasContext.fillText('Click to Begin', canvas.width/2, canvas.height/2 + 100)
+    canvasContext.font = '30px Arial'
+    canvasContext.fillStyle = '#0099CC'
+    canvasContext.fillText('Click to Begin', canvas.width/2, canvas.height/2 + 100)
+
   canvas.addEventListener('click', function(evt) {
-    // alert('clicked inside canvas')
-    main()
+    gamePlay()
   })
 
-function main () {
-  
+function gamePlay() {
+
 function calculateMousePos(evt) {
   let rect = canvas.getBoundingClientRect()
   let root = document.documentElement
@@ -60,7 +60,7 @@ function handleMouseClick(evt) {
 // let canvasContext = canvas.getContext('2d')
 
 let framesPerSecond = 30
-setInterval(function() {
+let timer = setInterval(function() {
   draw()
   move()
 }, 1000/framesPerSecond)
@@ -158,6 +158,7 @@ function draw() {
         canvasContext.fillText("Computer wins", 400, 200)
     }
     canvasContext.fillText("click to continue", 400, 400)
+    clearInterval(timer)
   }
 
   drawNet()


### PR DESCRIPTION
- To fix a bug where the speed of the ball would increase faster when
when clicking continue to start game again, I named the `setInterval`
as variable `timer` and added `clearInterval(timer)` to the
 `showingWinScreen` if statement in the `draw` function.